### PR TITLE
refactor(meeting): handle empty subMeetingId in requestUri

### DIFF
--- a/src/utils/meeting.ts
+++ b/src/utils/meeting.ts
@@ -511,7 +511,10 @@ export async function getMeetingParticipants(
     subMeetingId: string
 ): Promise<MeetingParticipantsResponse> {
     try {
-        const requestUri = `/v1/meetings/${meetingId}/participants?sub_meeting_id=${subMeetingId}&userid=${userId}`;
+        // 根据 subMeetingId 是否为空来构建 requestUri
+        const requestUri = subMeetingId
+            ? `/v1/meetings/${meetingId}/participants?sub_meeting_id=${subMeetingId}&userid=${userId}`
+            : `/v1/meetings/${meetingId}/participants?userid=${userId}`;
         const apiUrl = `https://api.meeting.qq.com${requestUri}`;
 
         // 1. 准备请求头参数


### PR DESCRIPTION
Conditionally construct the requestUri based on whether subMeetingId is provided. This ensures the API endpoint is correctly formed even when subMeetingId is absent, improving robustness and avoiding potential errors.